### PR TITLE
Combined dependencies PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "color": "^4.2.3",
         "favicons": "^6.2.2",
         "image-webpack-loader": "^8.1.0",
-        "immer": "^9.0.12",
+        "immer": "^9.0.14",
         "lodash": "^4.17.20",
         "lucide-react": "^0.54.0",
         "mini-svg-data-uri": "^1.4.4",
@@ -6574,9 +6574,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
-      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16265,9 +16265,9 @@
       }
     },
     "immer": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
-      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw=="
     },
     "immutable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "color": "^4.2.3",
     "favicons": "^6.2.2",
     "image-webpack-loader": "^8.1.0",
-    "immer": "^9.0.12",
+    "immer": "^9.0.14",
     "lodash": "^4.17.20",
     "lucide-react": "^0.54.0",
     "mini-svg-data-uri": "^1.4.4",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump immer from 9.0.12 to 9.0.14 (#149) @dependabot
* Bump sass from 1.50.0 to 1.52.1 (#148) @dependabot
* Bump sass-loader from 12.6.0 to 13.0.0 (#147) @dependabot
* Bump pixi.js-legacy from 6.3.0 to 6.4.2 (#145) @dependabot
* Bump react-dom from 18.0.0 to 18.1.0 (#138) @dependabot
* Bump lucide-react from 0.54.0 to 0.57.0 (#137) @dependabot
