### PR TITLE
Combined dependencies PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@jsdevtools/readdir-enhanced": "^6.0.4",
-        "@playwright/test": "^1.22.2",
+        "@playwright/test": "^1.23.0",
         "eslint": "^8.17.0",
         "eslint-config-next": "^12.1.6",
         "eslint-webpack-plugin": "^3.1.1",
@@ -1349,13 +1349,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.0.tgz",
+      "integrity": "sha512-RPWI8AHBVBiDyfTuxi1BhOaY3yaVy3S5ZsGKkSGGeWpZtSgN4SerInCYvgh9+EunIAK4RJQo+bzupbAn5pVqHQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright-core": "1.23.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8499,9 +8499,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.0.tgz",
+      "integrity": "sha512-Zzhyr5RZGoJ1ek2sgfJCt2076kdOg8hnNwFBqAYeLySiutXyxSQk93vZ5gbnFiWV1sHvueCcwla9n35acUTxtA==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -12185,13 +12185,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.0.tgz",
+      "integrity": "sha512-RPWI8AHBVBiDyfTuxi1BhOaY3yaVy3S5ZsGKkSGGeWpZtSgN4SerInCYvgh9+EunIAK4RJQo+bzupbAn5pVqHQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright-core": "1.23.0"
       }
     },
     "@rushstack/eslint-patch": {
@@ -17736,9 +17736,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.0.tgz",
+      "integrity": "sha512-Zzhyr5RZGoJ1ek2sgfJCt2076kdOg8hnNwFBqAYeLySiutXyxSQk93vZ5gbnFiWV1sHvueCcwla9n35acUTxtA==",
       "dev": true
     },
     "pngjs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@jsdevtools/readdir-enhanced": "^6.0.4",
-    "@playwright/test": "^1.22.2",
+    "@playwright/test": "^1.23.0",
     "eslint": "^8.17.0",
     "eslint-config-next": "^12.1.6",
     "eslint-webpack-plugin": "^3.1.1",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump @playwright/test from 1.22.2 to 1.23.0 (#172) @dependabot
* Bump sass-loader from 13.0.0 to 13.0.2 (#171) @dependabot
* Bump lucide-react from 0.61.0 to 0.70.0 (#170) @dependabot
* Bump eslint-webpack-plugin from 3.1.1 to 3.2.0 (#168) @dependabot
* Bump sass from 1.52.3 to 1.53.0 (#167) @dependabot
* Bump react-dom from 18.1.0 to 18.2.0 (#162) @dependabot
* Bump react from 18.1.0 to 18.2.0 (#161) @dependabot
